### PR TITLE
op-build update 10-19-2017

### DIFF
--- a/openpower/package/occ/occ.mk
+++ b/openpower/package/occ/occ.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 OCC_VERSION_BRANCH_MASTER_P8 ?= 28f2cec690b7f19548ce860a8820f519e6c39a6a
-OCC_VERSION_BRANCH_MASTER ?= cff91e53cc1a8324654b52d63a2620045c2b0b32
+OCC_VERSION_BRANCH_MASTER ?= bacb45ad1cc0da113290f0e169c33e5f0885c171
 
 OCC_VERSION ?= $(if $(BR2_OPENPOWER_POWER9),$(OCC_VERSION_BRANCH_MASTER),$(OCC_VERSION_BRANCH_MASTER_P8))
 OCC_SITE ?= $(call github,open-power,occ,$(OCC_VERSION))


### PR DESCRIPTION
Changes Included for package occ, branch master:
bacb45a - William Bryan - 2017-10-19 - GPU Timing Measurement Debug Command
c07a720 - Chris Cain - 2017-10-19 - Read VRM Vdd Temperatures
e00c5e2 - Doug Gilbert - 2017-10-19 - Add pointers to all gpe trace buffers in gpe shared data.
619a19c - Doug Gilbert - 2017-10-19 - Timebase overflow issue in gpe0
1522d76 - Andres Lugo-Reyes - 2017-10-19 - Prevent Over-Current scenario caused by vdd ratio calculations
50cfdf2 - Andres Lugo-Reyes - 2017-10-19 - Prevent WOF related error logs in states that don't support WOF
53f78de - Andres Lugo-Reyes - 2017-10-19 - Request WOF resets on OpenPower systems only.
bcc1e17 - mbroyles - 2017-10-18 - Support for GPU config format version 2
fa085f9 - Andres Lugo-Reyes - 2017-10-16 - Prevent PGPE IPC communication if all cores are deconfigured
051cc0a - mbroyles - 2017-10-16 - VRM Vdd Interfaces
d4fb4c3 - mbroyles - 2017-10-16 - Limit max frequency in oversubscription to prevent PS OC