### PR TITLE
petitboot: Bump to v1.6.2

### DIFF
--- a/openpower/package/petitboot/petitboot.mk
+++ b/openpower/package/petitboot/petitboot.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PETITBOOT_VERSION = v1.6.1
+PETITBOOT_VERSION = v1.6.2
 PETITBOOT_SITE ?= $(call github,open-power,petitboot,$(PETITBOOT_VERSION))
 PETITBOOT_DEPENDENCIES = ncurses udev host-bison host-flex lvm2
 PETITBOOT_LICENSE = GPLv2


### PR DESCRIPTION
Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>
(cherry picked from commit bc616dc255339f1345090b3a10985991c61de5bc)
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>


```
$ git log v1.6.1..v1.6.2
commit 093178c4a93ab6f25aa40101de1910368260228f (tag: v1.6.2, origin/master)
Author: Samuel Mendoza-Jonas <sam@mendozajonas.com>
Date:   Thu Oct 26 14:10:57 2017 +1100

    discover/platform-powerpc: Increase IPMI timeout
    
    On OpenBMC platforms IPMI requests can take over five seconds to
    complete. OpenBMC does inform OPAL in BT init that it may take up to
    ten seconds to respond to any requests, so update our timeout value to
    accommodate this extra delay.
    
    On other platforms this will won't change anything (AMI- and SMC- based
    BMCs for example respond in under a second), but on OpenBMC platforms
    such as Witherspoon this will delay Petitboot significantly while we
    wait for the response. This is not ideal but we need to wait in order to
    receive important information such as a safe mode request.
    
    Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>

commit 24ccb34938342f414b888553882ef2ee976d02a0
Author: Samuel Mendoza-Jonas <sam@mendozajonas.com>
Date:   Thu Oct 12 14:46:15 2017 +1100

    ui/ncurses: Remove help shortcut from nc-subset
    
    Subset screens do not include a help screen, so remove the misleading
    "h=help" shortcut from the lower frame title.
    
    Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>
```