### PR TITLE
Bump ppe42-gcc to c13849780c80d1ed466efbeaabcc663fe48cd87d

### DIFF
--- a/openpower/package/ppe42-gcc/ppe42-gcc.mk
+++ b/openpower/package/ppe42-gcc/ppe42-gcc.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PPE42_GCC_VERSION ?= d8a1bac8634033a3edd4e9a22455f97318718f43
+PPE42_GCC_VERSION ?= c13849780c80d1ed466efbeaabcc663fe48cd87d
 PPE42_GCC_SITE ?= $(call github,open-power,ppe42-gcc,$(PPE42_GCC_VERSION))
 PPE42_GCC_LICENSE = GPLv3+
 


### PR DESCRIPTION
Doug Gilbert (4):
      Prevent unsupported load/store index updateinstructions on PPE
      Indicate that PPE42 fused branch instructions modify the CR
      unsupported insn for bswap emitted
      Merge pull request #5 from dgilbert999/gcc-4_9_2-ppe42

Douglas Gilbert (1):
      Fix compile issue when compiling with gcc 6

Patrick Williams (2):
      Merge pull request #3 from dgilbert999/gcc-4_9_2-ppe42
      Merge pull request #4 from dgilbert999/gcc-4_9_2-ppe42

Suggested-by: Douglas Gilbert <dgilbert999@netscape.net>
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>