### PR TITLE
Set access to HBB and HBI partitions to Read Only

### DIFF
--- a/openpower/package/openpower-pnor/openpower-pnor.mk
+++ b/openpower/package/openpower-pnor/openpower-pnor.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-OPENPOWER_PNOR_VERSION ?= b210f15c69933e21494323a8f5017501e7b2c1de
-OPENPOWER_PNOR_SITE ?= $(call github,open-power,pnor,$(OPENPOWER_PNOR_VERSION))
+OPENPOWER_PNOR_VERSION ?= 26e9e30c90085747305bf809aaa16aac81f79878
+OPENPOWER_PNOR_SITE ?= $(call github,ibm-op-release,pnor,$(OPENPOWER_PNOR_VERSION))
 
 OPENPOWER_PNOR_LICENSE = Apache-2.0
 OPENPOWER_PNOR_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This change updates the pnor makefiles to ensure HBB and HBI
partitions are marked read only at the pnor level.

Signed-off-by: Jaymes Wilks <mjwilks@us.ibm.com>