### PR TITLE
Remove patch folder variable from mihawk_defconfig

### DIFF
--- a/openpower/configs/mihawk_defconfig
+++ b/openpower/configs/mihawk_defconfig
@@ -1,6 +1,5 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
-BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_OP_BUILD_PATH)/patches/mihawk-patches"
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_GCC_VERSION_6_X=y
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"


### PR DESCRIPTION
Modify: remove BR2_GLOBAL_PATCH_DIR from mihawk_defconfig

Signed-off-by: Joy Chu <joy_chu@wistron.com>