### PR TITLE
Modify kernel partition size for some built-in tools

### DIFF
--- a/openpower/configs/mihawk_defconfig
+++ b/openpower/configs/mihawk_defconfig
@@ -1,5 +1,6 @@
 BR2_powerpc64le=y
 BR2_powerpc_power8=y
+BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_OP_BUILD_PATH)/patches/mihawk-patches"
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
 BR2_GCC_VERSION_6_X=y
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"

--- a/openpower/patches/mihawk-patches/openpower-pnor/openpower-pnor-20191118-change-kernel-size-to-24MB.patch
+++ b/openpower/patches/mihawk-patches/openpower-pnor/openpower-pnor-20191118-change-kernel-size-to-24MB.patch
@@ -1,0 +1,161 @@
+diff --git a/p9Layouts/defaultPnorLayout_64.xml b/p9Layouts/defaultPnorLayout_64.xml
+index 3f74223..86b8053 100644
+--- a/p9Layouts/defaultPnorLayout_64.xml
++++ b/p9Layouts/defaultPnorLayout_64.xml
+@@ -222,10 +222,10 @@ Layout Description
+         <readOnly/>
+     </section>
+     <section>
+-        <description>Bootloader Kernel (15.5MB)</description>
++        <description>Bootloader Kernel (24MB)</description>
+         <eyeCatch>BOOTKERNEL</eyeCatch>
+         <physicalOffset>0x2141000</physicalOffset>
+-        <physicalRegionSize>0xF80000</physicalRegionSize>
++        <physicalRegionSize>0x1800000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+         <readOnly/>
+@@ -233,7 +233,7 @@ Layout Description
+     <section>
+         <description>OCC Lid (1.125M)</description>
+         <eyeCatch>OCC</eyeCatch>
+-        <physicalOffset>0x30C1000</physicalOffset>
++        <physicalOffset>0x3941000</physicalOffset>
+         <physicalRegionSize>0x120000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -243,7 +243,7 @@ Layout Description
+     <section>
+         <description>Checkstop FIR data (12K)</description>
+         <eyeCatch>FIRDATA</eyeCatch>
+-        <physicalOffset>0x31E1000</physicalOffset>
++        <physicalOffset>0x3A61000</physicalOffset>
+         <physicalRegionSize>0x3000</physicalRegionSize>
+         <side>A</side>
+         <ecc/>
+@@ -253,7 +253,7 @@ Layout Description
+     <section>
+         <description>CAPP Lid (144K)</description>
+         <eyeCatch>CAPP</eyeCatch>
+-        <physicalOffset>0x31E4000</physicalOffset>
++        <physicalOffset>0x3A64000</physicalOffset>
+         <physicalRegionSize>0x24000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -263,7 +263,7 @@ Layout Description
+     <section>
+         <description>BMC Inventory (36K)</description>
+         <eyeCatch>BMC_INV</eyeCatch>
+-        <physicalOffset>0x3208000</physicalOffset>
++        <physicalOffset>0x3A88000</physicalOffset>
+         <physicalRegionSize>0x9000</physicalRegionSize>
+         <side>sideless</side>
+         <reprovision/>
+@@ -271,7 +271,7 @@ Layout Description
+     <section>
+         <description>Hostboot Bootloader (28K)</description>
+         <eyeCatch>HBBL</eyeCatch>
+-        <physicalOffset>0x3211000</physicalOffset>
++        <physicalOffset>0x3A91000</physicalOffset>
+         <!-- Physical Size includes Header rounded to ECC valid size -->
+         <!-- Max size of actual HBBL content is 20K and 22.5K with ECC -->
+         <physicalRegionSize>0x7000</physicalRegionSize>
+@@ -283,7 +283,7 @@ Layout Description
+     <section>
+         <description>Temporary Attribute Override (32K)</description>
+         <eyeCatch>ATTR_TMP</eyeCatch>
+-        <physicalOffset>0x3218000</physicalOffset>
++        <physicalOffset>0x3A98000</physicalOffset>
+         <physicalRegionSize>0x8000</physicalRegionSize>
+         <side>A</side>
+         <reprovision/>
+@@ -291,7 +291,7 @@ Layout Description
+     <section>
+         <description>Permanent Attribute Override (32K)</description>
+         <eyeCatch>ATTR_PERM</eyeCatch>
+-        <physicalOffset>0x3220000</physicalOffset>
++        <physicalOffset>0x3AA0000</physicalOffset>
+         <physicalRegionSize>0x8000</physicalRegionSize>
+         <side>A</side>
+         <ecc/>
+@@ -301,7 +301,7 @@ Layout Description
+     <section>
+         <description>PNOR Version (4K)</description>
+         <eyeCatch>VERSION</eyeCatch>
+-        <physicalOffset>0x3228000</physicalOffset>
++        <physicalOffset>0x3AA8000</physicalOffset>
+         <physicalRegionSize>0x2000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -310,7 +310,7 @@ Layout Description
+     <section>
+         <description>IMA Catalog (256K)</description>
+         <eyeCatch>IMA_CATALOG</eyeCatch>
+-        <physicalOffset>0x322A000</physicalOffset>
++        <physicalOffset>0x3AAA000</physicalOffset>
+         <physicalRegionSize>0x40000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -320,7 +320,7 @@ Layout Description
+     <section>
+         <description>Ref Image Ring Overrides (128K)</description>
+         <eyeCatch>RINGOVD</eyeCatch>
+-        <physicalOffset>0x326A000</physicalOffset>
++        <physicalOffset>0x3AEA000</physicalOffset>
+         <physicalRegionSize>0x20000</physicalRegionSize>
+         <side>A</side>
+     </section>
+@@ -329,7 +329,7 @@ Layout Description
+         <!-- We need 266KB per module sort, going to support
+              10 sorts by default, plus ECC  -->
+         <eyeCatch>WOFDATA</eyeCatch>
+-        <physicalOffset>0x328A000</physicalOffset>
++        <physicalOffset>0x3B0A000</physicalOffset>
+         <physicalRegionSize>0x300000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -339,7 +339,7 @@ Layout Description
+     <section>
+         <description>Hostboot deconfig area (64KB)</description>
+         <eyeCatch>HB_VOLATILE</eyeCatch>
+-        <physicalOffset>0x358A000</physicalOffset>
++        <physicalOffset>0x3E0A000</physicalOffset>
+         <physicalRegionSize>0x5000</physicalRegionSize>
+         <side>A</side>
+         <reprovision/>
+@@ -350,7 +350,7 @@ Layout Description
+     <section>
+         <description>Memory config data (28K)</description>
+         <eyeCatch>MEMD</eyeCatch>
+-        <physicalOffset>0x358F000</physicalOffset>
++        <physicalOffset>0x3E0F000</physicalOffset>
+         <physicalRegionSize>0xE000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -360,7 +360,7 @@ Layout Description
+     <section>
+         <description>SecureBoot Key Transition Partition (16K)</description>
+         <eyeCatch>SBKT</eyeCatch>
+-        <physicalOffset>0x359D000</physicalOffset>
++        <physicalOffset>0x3E1D000</physicalOffset>
+         <physicalRegionSize>0x4000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+@@ -370,7 +370,7 @@ Layout Description
+     <section>
+         <description>HDAT binary data (32KB)</description>
+         <eyeCatch>HDAT</eyeCatch>
+-        <physicalOffset>0x35A1000</physicalOffset>
++        <physicalOffset>0x3E21000</physicalOffset>
+         <physicalRegionSize>0x8000</physicalRegionSize>
+         <side>sideless</side>
+         <sha512Version/>
+@@ -380,7 +380,7 @@ Layout Description
+     <section>
+         <description>Ultravisor binary image (1MB)</description>
+         <eyeCatch>UVISOR</eyeCatch>
+-        <physicalOffset>0x35A9000</physicalOffset>
++        <physicalOffset>0x3E29000</physicalOffset>
+         <physicalRegionSize>0x100000</physicalRegionSize>
+         <side>sideless</side>
+         <sha512Version/>


### PR DESCRIPTION
Add openpower-pnor patch file to increase Bootloader Kernel partition size to 24MB for built-in RAID tool support

Signed-off-by: Joy Chu <joy_chu@wistron.com>