### PR TITLE
Mihawk: add skiboot patch to force PEC2 to Gen3

### DIFF
--- a/openpower/patches/mihawk-patches/skiboot/0001-hw-phb4-Rework-max-link-speed-configuration.patch
+++ b/openpower/patches/mihawk-patches/skiboot/0001-hw-phb4-Rework-max-link-speed-configuration.patch
@@ -1,0 +1,118 @@
+From d2dca92ab8a1cc6d58be8db135ae9dcf3679e56b Mon Sep 17 00:00:00 2001
+From: Oliver O'Halloran <oohall@gmail.com>
+Date: Fri, 13 Dec 2019 13:11:47 +1100
+Subject: [PATCH 1/3] hw/phb4: Rework max-link-speed configuration
+
+Move the DT checking into phb4_create(), use the existing phb4_is_dd20()
+helper and de-convolute some of the control flow and get in the
+reverse-christmas spirit.
+
+Signed-off-by: Oliver O'Halloran <oohall@gmail.com>
+---
+ hw/phb4.c | 55 ++++++++++++++++++++++++-------------------------------
+ 1 file changed, 24 insertions(+), 31 deletions(-)
+
+diff --git a/hw/phb4.c b/hw/phb4.c
+index c932cf98..b5243509 100644
+--- a/hw/phb4.c
++++ b/hw/phb4.c
+@@ -236,6 +236,15 @@ static void phb4_write_reg(struct phb4 *p, uint32_t offset, uint64_t val)
+ 		return out_be64(p->regs + offset, val);
+ }
+ 
++static bool phb4_is_dd20(struct phb4 *p)
++{
++	struct proc_chip *chip = get_chip(p->chip_id);
++
++	if (p->rev == PHB4_REV_NIMBUS_DD20 && ((0xf & chip->ec_level) == 0))
++		return true;
++	return false;
++}
++
+ /* Helper to select an IODA table entry */
+ static inline void phb4_ioda_sel(struct phb4 *p, uint32_t table,
+ 				 uint32_t addr, bool autoinc)
+@@ -2868,33 +2877,24 @@ static int64_t phb4_poll_link(struct pci_slot *slot)
+ 	return OPAL_HARDWARE;
+ }
+ 
+-static unsigned int phb4_get_max_link_speed(struct phb4 *p, struct dt_node *np)
++static unsigned int phb4_get_max_link_speed(struct phb4 *p)
+ {
++	struct proc_chip *chip = get_chip(p->chip_id);
+ 	unsigned int max_link_speed;
+-	struct proc_chip *chip;
+-	chip = get_chip(p->chip_id);
+ 
+ 	/* Priority order: NVRAM -> dt -> GEN3 dd2.00 -> GEN4 */
+ 	max_link_speed = 4;
+-	if (p->rev == PHB4_REV_NIMBUS_DD20 &&
+-	    ((0xf & chip->ec_level) == 0) && chip->ec_rev == 0)
++
++	/* DD2.00 chips are known to have reliability issues at Gen4 */
++	if (phb4_is_dd20(p) && chip->ec_rev == 0)
+ 		max_link_speed = 3;
+-	if (np) {
+-		if (dt_has_node_property(np, "ibm,max-link-speed", NULL)) {
+-			max_link_speed = dt_prop_get_u32(np, "ibm,max-link-speed");
+-			p->dt_max_link_speed = max_link_speed;
+-		}
+-		else {
+-			p->dt_max_link_speed = 0;
+-		}
+-	}
+-	else {
+-		if (p->dt_max_link_speed > 0) {
+-			max_link_speed = p->dt_max_link_speed;
+-		}
+-	}
+-	if (pcie_max_link_speed)
++
++	if (p->dt_max_link_speed)
++		max_link_speed = p->dt_max_link_speed;
++
++	if (pcie_max_link_speed) /* nvram setting */
+ 		max_link_speed = pcie_max_link_speed;
++
+ 	if (max_link_speed > 4) /* clamp to 4 */
+ 		max_link_speed = 4;
+ 
+@@ -2997,7 +2997,7 @@ static int64_t phb4_freset(struct pci_slot *slot)
+ 		PHBDBG(p, "FRESET: Starts\n");
+ 
+ 		/* Reset max link speed for training */
+-		p->max_link_speed = phb4_get_max_link_speed(p, NULL);
++		p->max_link_speed = phb4_get_max_link_speed(p);
+ 
+ 		PHBDBG(p, "FRESET: Prepare for link down\n");
+ 		phb4_prepare_link_change(slot, false);
+@@ -4006,15 +4006,6 @@ static uint64_t tve_encode_50b_noxlate(uint64_t start_addr, uint64_t end_addr)
+ 	return tve;
+ }
+ 
+-static bool phb4_is_dd20(struct phb4 *p)
+-{
+-	struct proc_chip *chip = get_chip(p->chip_id);
+-
+-	if (p->rev == PHB4_REV_NIMBUS_DD20 && ((0xf & chip->ec_level) == 0))
+-		return true;
+-	return false;
+-}
+-
+ static int64_t phb4_get_capp_info(int chip_id, struct phb *phb,
+ 				  struct capp_info *info)
+ {
+@@ -5673,7 +5664,9 @@ static void phb4_create(struct dt_node *np)
+ 	if (!phb4_read_capabilities(p))
+ 		goto failed;
+ 
+-	p->max_link_speed = phb4_get_max_link_speed(p, np);
++	p->dt_max_link_speed = dt_prop_get_u32_def(np, "ibm,max-link-speed", 0);
++	p->max_link_speed = phb4_get_max_link_speed(p);
++
+ 	PHBINF(p, "Max link speed: GEN%i\n", p->max_link_speed);
+ 
+ 	/* Check for lane equalization values from HB or HDAT */
+-- 
+2.17.1
+

--- a/openpower/patches/mihawk-patches/skiboot/0002-mihawk-Limit-riser-slots-to-Gen3-by-default.patch
+++ b/openpower/patches/mihawk-patches/skiboot/0002-mihawk-Limit-riser-slots-to-Gen3-by-default.patch
@@ -1,0 +1,144 @@
+From 08b212d56c9ebd52fbbbbb7d38fd09f253183347 Mon Sep 17 00:00:00 2001
+From: Oliver O'Halloran <oohall@gmail.com>
+Date: Fri, 13 Dec 2019 12:08:29 +1100
+Subject: [PATCH 2/3] mihawk: Limit riser slots to Gen3 by default
+
+Some of mihawk's PCIe risers have SI issues which can be worked around
+by limiting them to Gen3 speeds
+
+Signed-off-by: Oliver O'Halloran <oohall@gmail.com>
+---
+ hw/phb4.c                 | 21 ++++++++++++++++++++
+ include/phb4-regs.h       |  4 ++++
+ include/phb4.h            |  2 ++
+ platforms/astbmc/mihawk.c | 42 ++++++++++++++++++++++++++++++++++++++-
+ 4 files changed, 68 insertions(+), 1 deletion(-)
+
+diff --git a/hw/phb4.c b/hw/phb4.c
+index b5243509..a0c9ac3a 100644
+--- a/hw/phb4.c
++++ b/hw/phb4.c
+@@ -2901,6 +2901,27 @@ static unsigned int phb4_get_max_link_speed(struct phb4 *p)
+ 	return max_link_speed;
+ }
+ 
++/*
++ * Has the same effect as the ibm,max-link-speed property.
++ * i.e. sets the default link speed, while allowing NVRAM
++ * overrides, etc to still take effect.
++ */
++void phb4_set_dt_max_link_speed(struct phb4 *p, int new_max)
++{
++	uint64_t scr;
++	int max;
++
++	/* update the stored setting */
++	p->dt_max_link_speed = new_max;
++
++	/* take into account nvram settings, etc */
++	max = phb4_get_max_link_speed(p);
++
++	scr = phb4_read_reg(p, PHB_PCIE_SCR);
++	scr = SETFIELD(PHB_PCIE_SCR_MAXLINKSPEED, scr, max);
++	phb4_write_reg(p, PHB_PCIE_SCR, scr);
++}
++
+ static void phb4_assert_perst(struct pci_slot *slot, bool assert)
+ {
+ 	struct phb4 *p = phb_to_phb4(slot->phb);
+diff --git a/include/phb4-regs.h b/include/phb4-regs.h
+index d2fc357b..875796e9 100644
+--- a/include/phb4-regs.h
++++ b/include/phb4-regs.h
+@@ -250,6 +250,10 @@
+ #define PHB_PCIE_HOTPLUG_STATUS		0x1A20
+ #define	  PHB_PCIE_HPSTAT_PRESENCE	PPC_BIT(10)
+ 
++#define PHB_PCIE_LMR		0x1A30
++#define   PHB_PCIE_LMR_CHANGE_WIDTH	PPC_BIT(0)
++#define   PHB_PCIE_LMR_RETRAIN_LINK	PPC_BIT(1)
++
+ #define PHB_PCIE_DLP_TRAIN_CTL		0x1A40
+ #define	  PHB_PCIE_DLP_LINK_WIDTH	PPC_BITMASK(30,35)
+ #define	  PHB_PCIE_DLP_LINK_SPEED	PPC_BITMASK(36,39)
+diff --git a/include/phb4.h b/include/phb4.h
+index 1c68ec2e..036b8a81 100644
+--- a/include/phb4.h
++++ b/include/phb4.h
+@@ -252,4 +252,6 @@ static inline int phb4_get_opal_id(unsigned int chip_id, unsigned int index)
+ 	return chip_id * PHB4_PER_CHIP + index;
+ }
+ 
++void phb4_set_dt_max_link_speed(struct phb4 *p, int new_max);
++
+ #endif /* __PHB4_H */
+diff --git a/platforms/astbmc/mihawk.c b/platforms/astbmc/mihawk.c
+index feae205f..290b34d3 100644
+--- a/platforms/astbmc/mihawk.c
++++ b/platforms/astbmc/mihawk.c
+@@ -14,6 +14,8 @@
+ #include <npu2.h>
+ #include <pci.h>
+ #include <pci-cfg.h>
++#include <phb4-regs.h>
++#include <phb4.h>
+ 
+ #include "astbmc.h"
+ 
+@@ -248,6 +250,43 @@ static bool mihawk_probe(void)
+ 	return true;
+ }
+ 
++
++/*
++ * Limit phb3 / (pec2) to gen3 speeds until we know the card (or riser)
++ * can support gen4 speeds.
++ */
++static void mihawk_setup_phb(struct phb *phb, unsigned int __unused index)
++{
++	struct phb4 *p = phb_to_phb4(phb);
++
++	if (p->pec == 2)
++		phb4_set_dt_max_link_speed(p, 3);
++}
++
++static void mihawk_pci_probe_complete(void)
++{
++	struct phb *phb;
++
++	for_each_phb(phb) {
++		struct phb4 *p = phb_to_phb4(phb);
++		struct pci_device *pd;
++
++		if (phb->phb_type != phb_type_pcie_v4 || p->pec != 2)
++			continue;
++
++		pd = pci_find_dev(phb, 0x0100);
++		if (!pd)
++			continue;
++		if (pd->vdid != 0x405211f8)
++			continue;
++
++		PCIERR(&p->phb, 0, "restoring to gen4\n");
++		phb4_set_dt_max_link_speed(p, 4);
++	}
++
++	check_all_slot_table();
++}
++
+ DECLARE_PLATFORM(mihawk) = {
+ 	.name			= "Mihawk",
+ 	.probe			= mihawk_probe,
+@@ -256,7 +295,8 @@ DECLARE_PLATFORM(mihawk) = {
+ 	.resource_loaded	= flash_resource_loaded,
+ 	.bmc			= &bmc_plat_ast2500_openbmc,
+ 	.pci_get_slot_info	= mihawk_get_slot_info,
+-	.pci_probe_complete	= check_all_slot_table,
++	.pci_probe_complete	= mihawk_pci_probe_complete,
++	.pci_setup_phb 		= mihawk_setup_phb,
+ 	.cec_power_down         = astbmc_ipmi_power_down,
+ 	.cec_reboot             = astbmc_ipmi_reboot,
+ 	.elog_commit		= ipmi_elog_commit,
+-- 
+2.17.1
+

--- a/openpower/patches/mihawk-patches/skiboot/0003-mihawk-add-multiple-gen4-switch-support.patch
+++ b/openpower/patches/mihawk-patches/skiboot/0003-mihawk-add-multiple-gen4-switch-support.patch
@@ -1,0 +1,53 @@
+From d70c4eb162b4a6aefdf3aee84a50c9edd58fe3d7 Mon Sep 17 00:00:00 2001
+From: Joy Chu <joy_chu@wistron.com>
+Date: Fri, 13 Dec 2019 18:24:41 +0800
+Subject: [PATCH 3/3] mihawk: add multiple gen4 switch support
+
+Add Microsemi Gen4 switch 405211f8 and 140011f8 support and add some trace for it.
+
+Signed-off-by: Joy Chu <joy_chu@wistron.com>
+---
+ platforms/astbmc/mihawk.c | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/platforms/astbmc/mihawk.c b/platforms/astbmc/mihawk.c
+index 290b34d3..83ffdf03 100644
+--- a/platforms/astbmc/mihawk.c
++++ b/platforms/astbmc/mihawk.c
+@@ -259,8 +259,11 @@ static void mihawk_setup_phb(struct phb *phb, unsigned int __unused index)
+ {
+ 	struct phb4 *p = phb_to_phb4(phb);
+ 
+-	if (p->pec == 2)
++	if (p->pec == 2) {
+ 		phb4_set_dt_max_link_speed(p, 3);
++		prlog(PR_DEBUG, "Mihawk: Force the PEC2 Speed to Gen3 ONLY    "
++                                "(chip_id=%d, pec=%d)\n", p->chip_id, p->pec);
++	}
+ }
+ 
+ static void mihawk_pci_probe_complete(void)
+@@ -277,11 +280,19 @@ static void mihawk_pci_probe_complete(void)
+ 		pd = pci_find_dev(phb, 0x0100);
+ 		if (!pd)
+ 			continue;
+-		if (pd->vdid != 0x405211f8)
++
++		/* If we find a Microsemi Gen4 Switch vdid=0x405211f8 or
++	           vdid=0x140011f8, which means it's the riser with Gen4 switch
++		   installed and the max speed should change from Gen3 to Gen4.
++		 */
++		if ((pd->vdid != 0x405211f8) && (pd->vdid != 0x140011f8))
+ 			continue;
+ 
+ 		PCIERR(&p->phb, 0, "restoring to gen4\n");
+ 		phb4_set_dt_max_link_speed(p, 4);
++		prlog(PR_DEBUG, "Mihawk: Detect Riser-F and Restore to Gen4   "
++				"(chip_id=%d, pec=%d, device=%08x)\n",
++				p->chip_id, p->pec, pd->vdid);
+ 	}
+ 
+ 	check_all_slot_table();
+-- 
+2.17.1
+


### PR DESCRIPTION
The workaround to restrict some riser slots to run Gen3 only

Signed-off-by: Joy Chu <joy_chu@wistron.com>