### PR TITLE
Skiboot: libstb/tpm: block access.. build patch

### DIFF
--- a/openpower/package/skiboot/0001-npu2-Clear-fence-on-all-bricks.patch
+++ b/openpower/package/skiboot/0001-npu2-Clear-fence-on-all-bricks.patch
@@ -1,0 +1,60 @@
+From aa8c95455a5ab0a94fbcacce6760c163c4ab4be2 Mon Sep 17 00:00:00 2001
+From: Alexey Kardashevskiy <aik@ozlabs.ru>
+Date: Fri, 22 Nov 2019 11:04:22 +1100
+Subject: [PATCH] npu2: Clear fence on all bricks
+
+[ Upstream commit 9be9a77a8352aee0bb74ac0d79f55e1238f76285 ]
+
+A bug in the NVidia driver can cause an UR HMI which fences bricks
+(links). At the moment we clear fence status only for bricks of a specific
+devices, however this does not appear to be enough and we need to clear
+fences for all bricks. This is ok as we do not allow using GPUs
+individually anyway.
+
+Signed-off-by: Alexey Kardashevskiy <aik@ozlabs.ru>
+Acked-by: Reza Arbab <arbab@linux.ibm.com>
+Signed-off-by: Oliver O'Halloran <oohall@gmail.com>
+Signed-off-by: Vasant Hegde <hegdevasant@linux.vnet.ibm.com>
+---
+ hw/npu2-hw-procedures.c | 17 ++++++++++++-----
+ 1 file changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/hw/npu2-hw-procedures.c b/hw/npu2-hw-procedures.c
+index 24447a46..4e245d2c 100644
+--- a/hw/npu2-hw-procedures.c
++++ b/hw/npu2-hw-procedures.c
+@@ -258,8 +258,8 @@ static bool poll_fence_status(struct npu2_dev *ndev, uint64_t val)
+ /* Procedure 1.2.1 - Reset NPU/NDL */
+ uint32_t reset_ntl(struct npu2_dev *ndev)
+ {
+-	uint64_t val;
+-	int lane;
++	uint64_t val, check;
++	int lane, i;
+ 
+ 	set_iovalid(ndev, true);
+ 
+@@ -277,10 +277,17 @@ uint32_t reset_ntl(struct npu2_dev *ndev)
+ 
+ 	/* Clear fence state for the brick */
+ 	val = npu2_read(ndev->npu, NPU2_MISC_FENCE_STATE);
+-	if (val & PPC_BIT(ndev->brick_index)) {
+-		NPU2DEVINF(ndev, "Clearing brick fence\n");
+-		val = PPC_BIT(ndev->brick_index);
++	if (val) {
++		NPU2DEVINF(ndev, "Clearing all bricks fence\n");
+ 		npu2_write(ndev->npu, NPU2_MISC_FENCE_STATE, val);
++		for (i = 0, check = 0; i < 4096; i++) {
++			check = npu2_read(ndev->npu, NPU2_NTL_CQ_FENCE_STATUS(ndev));
++			if (!check)
++				break;
++		}
++		if (check)
++			NPU2DEVERR(ndev, "Clearing NPU2_MISC_FENCE_STATE=0x%llx timeout, current=0x%llx\n",
++					val, check);
+ 	}
+ 
+ 	/* Write PRI */
+-- 
+2.17.1
+


### PR DESCRIPTION
Carry the below patch from upstream while we don't have a
stable-Skiboot-6.5.x release containing it.

    Author: Oliver O'Halloran <oohall@gmail.com>
    Date:   Tue Dec 3 16:46:19 2019 +1100

    libstb/tpm: block access to unknown i2c devs on the tpm bus

    [ Upstream commit 9f7b726ccf7ee9b6fe50277e79e0bd285bfa9918 ]

    Our favourite TPM is capable of listening on multiple I2C bus addresses
    and although this feature is supposed to be disabled by default we have
    some systems in the wild where the TPM appears to be listening on these
    secondary addresses.

    The secondary addresses are also susceptible to the bus-lockup problem
    that we see with certain traffic patterns to the "main" TPM address.
    We don't know what addresses the TPM might be listening on it's best to
    take a conservitve approach and only allow traffic to I2C bus addresses
    that we are explicitly told about by firmware.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>