### PR TITLE
skiroot_defconfig: blacklist xhci_hdc module

### DIFF
--- a/openpower/configs/linux/skiroot_defconfig
+++ b/openpower/configs/linux/skiroot_defconfig
@@ -47,7 +47,7 @@ CONFIG_NUMA=y
 CONFIG_PPC_64K_PAGES=y
 CONFIG_SCHED_SMT=y
 CONFIG_CMDLINE_BOOL=y
-CONFIG_CMDLINE="console=tty0 console=hvc0 ipr.fast_reboot=1 quiet"
+CONFIG_CMDLINE="console=tty0 console=hvc0 ipr.fast_reboot=1 module_blacklist=xhci_hcd quiet"
 # CONFIG_SECCOMP is not set
 # CONFIG_PPC_MEM_KEYS is not set
 CONFIG_PPC_SECURE_BOOT=y


### PR DESCRIPTION
This downstram-only change is required on Mowgli to ensure that the usb0
interface won't be reset between host reboots.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>