### PR TITLE
Define BR2_OPENPOWER_MACHINE_XML_GITHUB_ORG_VALUE Var in machine-xml

### DIFF
--- a/openpower/package/machine-xml/Config.in
+++ b/openpower/package/machine-xml/Config.in
@@ -5,6 +5,11 @@ config BR2_PACKAGE_MACHINE_XML
         default y if (BR2_OPENPOWER_PLATFORM)
         select BR2_PACKAGE_COMMON_P8_XML if (BR2_OPENPOWER_POWER8)
 
+config BR2_OPENPOWER_MACHINE_XML_GITHUB_ORG_VALUE
+        string "The Github organization name (e.g. open-power)"
+        default "open-power"
+        depends on BR2_OPENPOWER_MACHINE_XML_GITHUB_PROJECT
+
 choice
 	prompt "Machine XML location"
 


### PR DESCRIPTION
The var was not defined, so setting it in witherspoon_defconfig was having no effect.